### PR TITLE
Handle GUI init failure

### DIFF
--- a/aggression_analyzer/main.py
+++ b/aggression_analyzer/main.py
@@ -1,8 +1,17 @@
 from dotenv import load_dotenv
 
 from gui.app import ModerationApp
+import tkinter as tk
+import sys
 
 if __name__ == "__main__":
     load_dotenv()
-    app = ModerationApp()
-    app.mainloop()
+    try:
+        app = ModerationApp()
+        app.mainloop()
+    except tk.TclError as e:
+        print(
+            "GUI initialization failed: a graphical display environment is required.",
+            file=sys.stderr,
+        )
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- fail gracefully if the GUI can't initialize

## Testing
- `pip install -r aggression_analyzer/requirements.txt`
- `python -m py_compile aggression_analyzer/main.py`
- `python aggression_analyzer/main.py` *(fails: AttributeError in snscrape)*

------
https://chatgpt.com/codex/tasks/task_e_686e55120b988333be5924412aa9c7c4