### PR TITLE
Add Japanese usage manual

### DIFF
--- a/"b/\346\223\215\344\275\234\350\252\254\346\230\216.md"
+++ b/"b/\346\223\215\344\275\234\350\252\254\346\230\216.md"
@@ -1,0 +1,51 @@
+# 操作説明（日本語）
+
+このドキュメントは、"Aggression Analyzer"（オールインワン誹謗中傷証拠収集ツール）を日本語で利用するための操作手順をまとめたものです。
+
+## 1. 準備
+
+1. Python 3.10 以上を推奨します。
+2. 依存パッケージをインストールします。
+   ```bash
+   pip install -r aggression_analyzer/requirements.txt
+   ```
+3. 環境変数ファイルを作成し、OpenAI の API キーを設定します。
+   ```bash
+   cp aggression_analyzer/.env.example aggression_analyzer/.env
+   # エディタで .env を開き、OPENAI_API_KEY を設定
+   ```
+
+## 2. アプリの起動
+
+以下のコマンドで GUI アプリケーションを起動します。
+```bash
+python aggression_analyzer/main.py
+```
+GUI を利用できない環境では、`xvfb-run` を利用します。
+```bash
+xvfb-run -a python aggression_analyzer/main.py
+```
+
+## 3. 使い方
+
+1. アプリ起動後、X（旧Twitter）のユーザーIDと取得件数を入力します。
+2. **収集＆分析開始** ボタンを押すと投稿取得と攻撃性分析が実行されます。
+3. 完了後、Excel 形式の結果ファイルを `aggression_analyzer/output/` に保存できます。
+
+## 4. テストの実行
+
+本プロジェクトには基本機能を検証するテストが含まれています。次のコマンドで実行できます。
+```bash
+pytest -q
+```
+全てのテストが成功すればセットアップは完了です。
+
+## 5. ディレクトリ構成
+
+- `aggression_analyzer/main.py` – アプリケーション起動用スクリプト
+- `aggression_analyzer/gui/app.py` – GUI の実装
+- `aggression_analyzer/modules/` – スクレイプと分析のモジュール
+- `aggression_analyzer/config/settings.py` – 設定値やプロンプトの定義
+- `aggression_analyzer/output/` – 結果ファイルの保存先
+
+以上が基本的な操作手順です。詳細は英語版 README (README.md) も参照してください。


### PR DESCRIPTION
## Summary
- add `操作説明.md` with Japanese instructions for using Aggression Analyzer

## Testing
- `pip install -r aggression_analyzer/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f4c2ec0608333a3ea3c499edf58c3