### PR TITLE
Add test for parallel analyzer

### DIFF
--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import pandas as pd
 from types import SimpleNamespace
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'aggression_analyzer'))
@@ -32,3 +33,43 @@ def test_get_aggressiveness_score(monkeypatch):
     score, reason = analyzer.get_aggressiveness_score('hello')
     assert score == 7
     assert reason == 'mocked'
+
+
+def test_analyze_dataframe_in_parallel(monkeypatch):
+    analyzer = Analyzer(api_key='test')
+
+    def fake_moderate_text(text: str):
+        categories = SimpleNamespace(
+            hate=False,
+            hate_threatening=False,
+            self_harm=False,
+            sexual=False,
+            sexual_minors=False,
+            violence=False,
+            violence_graphic=False,
+        )
+        scores = SimpleNamespace(
+            hate=0.1,
+            hate_threatening=0.2,
+            self_harm=0.0,
+            sexual=0.0,
+            sexual_minors=0.0,
+            violence=0.0,
+            violence_graphic=0.0,
+        )
+        return categories, scores
+
+    monkeypatch.setattr(analyzer, "moderate_text", fake_moderate_text)
+    monkeypatch.setattr(analyzer, "get_aggressiveness_score", lambda text: (5, "ok"))
+
+    df = pd.DataFrame({"content": ["a", "b", "c"]})
+    progress = []
+
+    def cb(done: int, total: int):
+        progress.append(done)
+
+    result = analyzer.analyze_dataframe_in_parallel(df, cb)
+
+    assert list(progress) == [1, 2, 3]
+    assert list(result["aggressiveness_score"]) == [5, 5, 5]
+    assert "total_aggression" in result.columns


### PR DESCRIPTION
## Summary
- add unit test covering `analyze_dataframe_in_parallel`

## Testing
- `pip install -r aggression_analyzer/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f7e80898c83339ce52587451667cb