### PR TITLE
Add configurable scrape delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ You can adjust this value to match your hardware resources and the
 rate limits of the OpenAI API. Increasing it speeds up large batch
 analysis at the cost of more simultaneous API calls.
 
+Scraping is performed serially to avoid rate limiting. The delay between
+requests can be adjusted with `SCRAPE_DELAY_SECONDS` in
+`config/settings.py`.
+
 ## Running Tests
 
 Basic functionality is covered by unit tests in the `tests/` directory. After installing the requirements, run:

--- a/aggression_analyzer/config/settings.py
+++ b/aggression_analyzer/config/settings.py
@@ -6,6 +6,10 @@ AGGRESSION_ANALYSIS_MODEL = "gpt-4o-mini"
 # 同時に実行する分析タスク数の上限
 MAX_CONCURRENT_WORKERS = 8
 
+# Scraper Settings
+# 1リクエストごとの待機秒数
+SCRAPE_DELAY_SECONDS = 1
+
 # Analysis Parameters
 DEFAULT_TEMPERATURE = 0.5
 DEFAULT_TOP_P = 1.0

--- a/aggression_analyzer/modules/scraper.py
+++ b/aggression_analyzer/modules/scraper.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import time
+from config.settings import SCRAPE_DELAY_SECONDS
 import pandas as pd
 
 try:
@@ -48,7 +49,7 @@ class Scraper:
                         "content": tweet.content,
                     }
                 )
-                time.sleep(1)
+                time.sleep(SCRAPE_DELAY_SECONDS)
         except Exception as e:
             print(f"scrape error: {e}")
             return pd.DataFrame()


### PR DESCRIPTION
## Summary
- make scraper delay configurable via `SCRAPE_DELAY_SECONDS`
- reference the new constant in README

## Testing
- `pip install -r aggression_analyzer/requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f807a95e48333beeb69f428c9c456