### PR TITLE
Fix README setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Aggression Analyzer is an all-in-one tool for collecting posts from X (formerly 
 Install the dependencies and create an environment file:
 
 ```bash
-pip install -r aggression_analyzer/requirements.txt
-cp aggression_analyzer/.env.example aggression_analyzer/.env
-# edit aggression_analyzer/.env and set OPENAI_API_KEY
+pip install -r requirements.txt
+cp aggression_analyzer/.env.example .env
+# edit .env and set OPENAI_API_KEY
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary
- correct installation path in README so it matches the manual and AGENT specs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870f425d0c08333bb6b611ee2bd2e4c