### PR TITLE
Handle row errors gracefully

### DIFF
--- a/aggression_analyzer/modules/analyzer.py
+++ b/aggression_analyzer/modules/analyzer.py
@@ -1,6 +1,7 @@
 import os
 import json
 import time
+import logging
 from typing import Tuple, List, Any, Callable, Optional
 
 import pandas as pd
@@ -108,8 +109,20 @@ class Analyzer:
         ]
 
         def process_row(index: int, text: str) -> tuple[int, dict[str, Any]]:
-            categories, scores = self.moderate_text(text)
-            score, reason = self.get_aggressiveness_score(text)
+            try:
+                categories, scores = self.moderate_text(text)
+                score, reason = self.get_aggressiveness_score(text)
+            except Exception:
+                logging.exception("Failed to process row %s", index)
+                result: dict[str, Any] = {
+                    "aggressiveness_score": None,
+                    "aggressiveness_reason": None,
+                }
+                for name in category_names:
+                    result[f"{name}_flag"] = False
+                    result[f"{name}_score"] = 0.0
+                return index, result
+
             result: dict[str, Any] = {
                 "aggressiveness_score": score,
                 "aggressiveness_reason": reason,

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -73,3 +73,45 @@ def test_analyze_dataframe_in_parallel(monkeypatch):
     assert list(progress) == [1, 2, 3]
     assert list(result["aggressiveness_score"]) == [5, 5, 5]
     assert "total_aggression" in result.columns
+
+
+def test_analyze_dataframe_in_parallel_error_row(monkeypatch):
+    analyzer = Analyzer(api_key='test')
+
+    categories = SimpleNamespace(
+        hate=False,
+        hate_threatening=False,
+        self_harm=False,
+        sexual=False,
+        sexual_minors=False,
+        violence=False,
+        violence_graphic=False,
+    )
+    scores = SimpleNamespace(
+        hate=0.0,
+        hate_threatening=0.0,
+        self_harm=0.0,
+        sexual=0.0,
+        sexual_minors=0.0,
+        violence=0.0,
+        violence_graphic=0.0,
+    )
+
+    def maybe_fail(text: str):
+        if text == "bad":
+            raise RuntimeError("boom")
+        return categories, scores
+
+    monkeypatch.setattr(analyzer, "moderate_text", maybe_fail)
+    monkeypatch.setattr(analyzer, "get_aggressiveness_score", lambda text: (5, "ok"))
+
+    df = pd.DataFrame({"content": ["a", "bad", "c"]})
+    progress = []
+
+    result = analyzer.analyze_dataframe_in_parallel(df, lambda d, t: progress.append(d))
+
+    assert list(progress) == [1, 2, 3]
+    assert pd.isna(result.loc[1, "aggressiveness_score"])
+    assert result.loc[1, "hate_score"] == 0.0
+    assert result.loc[0, "aggressiveness_score"] == 5
+    assert result.loc[2, "aggressiveness_score"] == 5


### PR DESCRIPTION
## Summary
- ensure analyzer row failures don't interrupt processing
- test that analysis continues after an exception

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6871cc14492c8333a04b59ab5c3c02bb